### PR TITLE
Initial z80-facing SD card support

### DIFF
--- a/teensy/sdcard.cpp
+++ b/teensy/sdcard.cpp
@@ -1,9 +1,49 @@
 #include <Arduino.h>
 #include <SD.h>
-#include <SD_t3.h>
 
 #include "debug.h"
+#include "z80.h"
 #include "sdcard.h"
+
+uint8_t sdcard_secnum_0 = 0x00;
+uint8_t sdcard_secnum_1 = 0x00;
+uint8_t sdcard_secnum_2 = 0x00;
+uint8_t sdcard_secnum_3 = 0x00;
+uint8_t sdcard_dma_addr_0 = 0x00;
+uint8_t sdcard_dma_addr_1 = 0xe0;
+uint8_t sdcard_dma_addr_2 = 0x80; // alternate modes not yet implemented
+uint8_t sdcard_sec_count = 0x01;
+
+uint8_t sdcard_status_byte = 0x80;
+uint16_t sdcard_sector_size = 128;
+uint16_t sdcard_dma_addr_local;
+uint32_t sdcard_secnum;
+uint32_t sdcard_dma_addr_global;
+
+uint8_t sdcard_sec_buf[512];
+
+// status byte bit definitions
+// bit 0-3 - selected disk (note - disk 15 is currently the custom filename 
+//           mounted disk)
+// bit 4-5 - currently selected sector size in bytes 00 = 128, 01 = 256,
+//           10 = 512, 11 = reserved for future expansion (1024 bytes?)
+// bit 6   - RO / RW flag - 0 = RW, 1 = RO (not yet implemented)
+// bit 7   - error flag - 0 = OK, 1 = error
+// initial status has error flag set since no disk is selected yet
+
+char sdcard_filename[12];
+File sdcard_image_file;
+
+uint8_t *reg_table[8] = {
+    &sdcard_secnum_0,       // sdcard_base_port
+    &sdcard_secnum_1,       // sdcard_base_port + 0x01
+    &sdcard_secnum_2,       // sdcard_base_port + 0x02
+    &sdcard_secnum_3,       // sdcard_base_port + 0x03
+    &sdcard_dma_addr_0,     // sdcard_base_port + 0x04
+    &sdcard_dma_addr_1,     // sdcard_base_port + 0x05
+    &sdcard_dma_addr_2,     // sdcard_base_port + 0x06
+    &sdcard_sec_count       // sdcard_base_port + 0x07
+};
 
 void sdcard_init() {
   report("ersatz80: initializing SD card...\r\n");
@@ -13,3 +53,234 @@ void sdcard_init() {
   }
 }
 
+void sdcard_reg_wr(uint8_t address, uint8_t value) {
+    *reg_table[address-sdcard_base_port] = value;
+}
+
+uint8_t sdcard_reg_rd(uint8_t address) {
+    return *reg_table[address-sdcard_base_port];
+}
+
+void sdcard_cmd_wr(uint8_t value) {
+    switch(value) {
+        // select disks 0-14, file names are 'disk<nn>.img'
+        case 0x00:
+        case 0x01:
+        case 0x02:
+        case 0x03:
+        case 0x04:
+        case 0x05:
+        case 0x06:
+        case 0x07:
+        case 0x08:
+        case 0x09:
+        case 0x0a:
+        case 0x0b:
+        case 0x0c:
+        case 0x0d:
+        case 0x0e:
+            sdcard_select_prenamed_disk(value);
+            break;
+        // select disk 15, file name is an 8.3 name located at the
+        // DMA address
+        case 0x0f:
+            report("Filename mounted disk not implemented yet");
+            break;
+        // set sector size
+        case 0x10:
+            sdcard_sector_size = 128;
+            sdcard_status_byte = sdcard_status_byte & 0b11001111;
+            break;
+        case 0x11:
+            sdcard_sector_size = 256;
+            sdcard_status_byte = (sdcard_status_byte & 0b11001111) | 0b00010000;
+            break;
+        case 0x12:
+            sdcard_sector_size = 512;
+            sdcard_status_byte = (sdcard_status_byte & 0b11001111) | 0b00100000;
+            break;
+        // perform disk read
+        case 0x13:
+            sdcard_disk_read();
+            break;
+        // perform disk write
+        case 0x14:
+            sdcard_disk_write();
+            break;
+        // list sdcard dir to DMA addr as null-terminated string
+        case 0x15:
+            report("Directory featured not implemented yet");
+            break;
+        case 0xFE:
+        // reset error flag after a failed operation
+            sdcard_status_byte = sdcard_status_byte & 0b01111111;                                 
+            break;
+        case 0xFF:
+        // debug listing of the sdcard routine variables
+            sdcard_reg_debug();
+            break;
+    }
+}   
+
+void sdcard_select_prenamed_disk(uint8_t disknum) {    
+    // close previous file if it was open
+    sdcard_image_file.close();
+    // build disk name filename
+    sprintf(sdcard_filename, "disk%02d.img", disknum);
+    // check if file exists, if so open, else error
+    sdcard_image_file = SD.open(sdcard_filename,(O_READ | O_WRITE));
+    if (sdcard_image_file) {
+        sdcard_status_byte = ((sdcard_status_byte & 0b01110000) | disknum);
+    } else {
+        report(sdcard_filename);
+        report(" does not exist \r\n");
+        sdcard_status_byte = sdcard_status_byte | 0b10000000;                 
+    }
+}
+
+void sdcard_disk_read() {
+    if ((sdcard_dma_addr_2 >> 6) == 0b00000010) {
+        // create a single variable representation of the sector number
+        sdcard_secnum = (sdcard_secnum_3 << 24) | (sdcard_secnum_2 << 16) | (sdcard_secnum_1 << 8) | (sdcard_secnum_0);
+        // create a single variable representatio of the DMA address
+        sdcard_dma_addr_local = (sdcard_dma_addr_1 << 8) | (sdcard_dma_addr_0);
+        // make sure there is enough data to read
+        if (sdcard_image_file.size() < ((sdcard_sector_size * sdcard_secnum) + (sdcard_sector_size * sdcard_sec_count))) {
+            report("not enough data available in file\r\n");
+            report("starting byte location %d\r\n",(sdcard_sector_size * sdcard_secnum));
+            report("ending byte location %d\r\n",((sdcard_sector_size * sdcard_secnum) + (sdcard_sector_size * sdcard_sec_count)));
+            report("file is %d bytes\r\n",sdcard_image_file.size());
+            sdcard_status_byte = sdcard_status_byte | 0b10000000; 
+            return;
+        }
+        // make sure there is enough RAM to write (sector count * size)
+        if (((sdcard_dma_addr_local-1) + (sdcard_sector_size * sdcard_sec_count)) > 0xffff) {
+            report("not enough RAM available above DMA location\r\n");
+            sdcard_status_byte = sdcard_status_byte | 0b10000000; 
+            return;
+        }
+        // seek to the correct sector in the file
+        if (!sdcard_image_file.seek(sdcard_sector_size * sdcard_secnum)) {
+            report("error seeking starting byte %d\r\n",(sdcard_sector_size * sdcard_secnum));
+            sdcard_status_byte = sdcard_status_byte | 0b10000000;  
+            return;
+        }
+        
+        // start DMA mode
+        begin_dma();
+
+        // stash current state
+        bool old_ram_ce = ram_ce;
+
+        // enable the SRAM
+        ram_ce = true;
+        shift_register_update();
+        
+        // loop for # of sectors required
+        int j, i;
+        for (j = sdcard_sec_count; j > 0; j--) {
+            // get sector from SD card
+            if (!sdcard_image_file.read(sdcard_sec_buf, sdcard_sector_size)) {
+                report("error reading sector to teensy ram buffer\r\n");
+                sdcard_status_byte = sdcard_status_byte | 0b10000000; 
+            }
+
+            // load 1 sector to SRAM 
+            for (i = 0; i < sdcard_sector_size; i++) {
+                z80_memory_write(sdcard_dma_addr_local++, sdcard_sec_buf[i]);
+            }
+        }
+
+        // restore machine state
+        ram_ce = old_ram_ce;
+        shift_register_update();
+        
+        //stop DMA mode
+        end_dma();        
+    } else if ((sdcard_dma_addr_2 >> 6) == 0b00000000) {
+        report("Alternate DMA address mode not yet implemented\r\n");
+    } else if ((sdcard_dma_addr_2 >> 6) == 0b00000001) {
+        report("Alternate DMA address mode not yet implemented\r\n");
+    }
+}
+
+void sdcard_disk_write() {
+    if ((sdcard_dma_addr_2 >> 6) == 0b00000010) {
+        // create a single variable representation of the sector number
+        sdcard_secnum = (sdcard_secnum_3 << 24) | (sdcard_secnum_2 << 16) | (sdcard_secnum_1 << 8) | (sdcard_secnum_0);
+        // create a single variable representatio of the DMA address
+        sdcard_dma_addr_local = (sdcard_dma_addr_1 << 8) | (sdcard_dma_addr_0);
+        // make sure there is enough room in file to write
+        if (sdcard_image_file.size() < ((sdcard_sector_size * sdcard_secnum) + (sdcard_sector_size * sdcard_sec_count))) {
+            report("not enough space available in file\r\n");
+            report("starting byte location %d\r\n",(sdcard_sector_size * sdcard_secnum));
+            report("ending byte location %d\r\n",((sdcard_sector_size * sdcard_secnum) + (sdcard_sector_size * sdcard_sec_count)));
+            report("file is %d bytes\r\n",sdcard_image_file.size());
+            sdcard_status_byte = sdcard_status_byte | 0b10000000; 
+            return;
+        }
+        // make sure there is enough RAM to hold all data being written (sector count * size)
+        if (((sdcard_dma_addr_local-1) + (sdcard_sector_size * sdcard_sec_count)) > 0xffff) {
+            report("not enough RAM available above DMA location\r\n");
+            sdcard_status_byte = sdcard_status_byte | 0b10000000; 
+            return;
+        }
+        // seek to the correct sector in the file
+        if (!sdcard_image_file.seek(sdcard_sector_size * sdcard_secnum)) {
+            report("error seeking starting byte %d\r\n",(sdcard_sector_size * sdcard_secnum));
+            sdcard_status_byte = sdcard_status_byte | 0b10000000;  
+            return;
+        }
+        
+        // start DMA mode
+        begin_dma();
+
+        // stash current state
+        bool old_ram_ce = ram_ce;
+
+        // enable the SRAM
+        ram_ce = true;
+        shift_register_update();
+        
+        // loop for # of sectors required
+        int j, i;
+        for (j = sdcard_sec_count; j > 0; j--) {
+            // copy 1 sector from SRAM
+            for (i = 0; i < sdcard_sector_size; i++) {
+                sdcard_sec_buf[i] = z80_memory_read(sdcard_dma_addr_local++);
+            }
+            // write sector to SD card
+            if (!sdcard_image_file.write(sdcard_sec_buf, sdcard_sector_size)) {
+                report("error writing sector to sdcard\r\n");
+                sdcard_status_byte = sdcard_status_byte | 0b10000000; 
+            }
+        }
+        // flush any remaining writes
+        sdcard_image_file.flush();
+        
+        // restore machine state
+        ram_ce = old_ram_ce;
+        shift_register_update();
+        
+        //stop DMA mode
+        end_dma();        
+    } else if ((sdcard_dma_addr_2 >> 6) == 0b00000000) {
+        report("Alternate DMA address mode not yet implemented\r\n");
+    } else if ((sdcard_dma_addr_2 >> 6) == 0b00000001) {
+        report("Alternate DMA address mode not yet implemented\r\n");
+    }
+}
+
+void sdcard_reg_debug() {
+    report("sdcard_secnum_0 = 0x%02x\r\n",sdcard_secnum_0);
+    report("sdcard_secnum_1 = 0x%02x\r\n",sdcard_secnum_1);
+    report("sdcard_secnum_2 = 0x%02x\r\n",sdcard_secnum_2);
+    report("sdcard_secnum_3 = 0x%02x\r\n",sdcard_secnum_3);
+    report("sdcard_dma_addr_0 = 0x%02x\r\n",sdcard_dma_addr_0);
+    report("sdcard_dma_addr_1 = 0x%02x\r\n",sdcard_dma_addr_1);
+    report("sdcard_dma_addr_2 = 0x%02x\r\n",sdcard_dma_addr_2);
+    report("sdcard_sec_count = %03d\r\n",sdcard_sec_count);
+    report("sdcard_selected_disk = %02d\r\n",(sdcard_status_byte & 0b00001111));
+    report("sdcard_sector_size = %02d\r\n",sdcard_sector_size);
+    report("sdcard_status_byte = 0x%02x\r\n",sdcard_status_byte);
+}

--- a/teensy/sdcard.h
+++ b/teensy/sdcard.h
@@ -3,10 +3,18 @@
 
 #include <Arduino.h>
 #include <SD.h>
-#include <SD_t3.h>
 
-#include "z80.h"
+const uint8_t sdcard_base_port = 0x90;
+
+extern uint8_t sdcard_status_byte;
 
 void sdcard_init(void); 
+void sdcard_reg_wr(uint8_t address, uint8_t value);
+uint8_t sdcard_reg_rd(uint8_t address);
+void sdcard_cmd_wr(uint8_t value);
+void sdcard_select_prenamed_disk(uint8_t disknum);
+void sdcard_disk_read(void);
+void sdcard_disk_write(void);
+void sdcard_reg_debug(void);
 
 #endif

--- a/teensy/teensy.ino
+++ b/teensy/teensy.ino
@@ -51,6 +51,17 @@ uint8_t iodevice_read(uint16_t address)
         case 0x7A: // bank2 page select -- Zeta2 compatible
         case 0x7B: // bank3 page select -- Zeta2 compatible
             return mmu[(address & 0xFF) - 0x78];
+        case sdcard_base_port:
+        case sdcard_base_port+0x01:
+        case sdcard_base_port+0x02:
+        case sdcard_base_port+0x03:
+        case sdcard_base_port+0x04:
+        case sdcard_base_port+0x05:
+        case sdcard_base_port+0x06:
+        case sdcard_base_port+0x07:
+            return sdcard_reg_rd((address & 0xFF));
+        case sdcard_base_port+0x0f:
+            return sdcard_status_byte;
         default:
             report("[IOR %04x]", address);
             return 0xAA;
@@ -80,6 +91,19 @@ void iodevice_write(uint16_t address, uint8_t value) // call ONLY when in DMA mo
             z80_bus_master();
             z80_set_mmu((address & 0xFF) - 0x78, value);
             z80_bus_slave();
+            break;
+        case sdcard_base_port:
+        case sdcard_base_port+0x01:
+        case sdcard_base_port+0x02:
+        case sdcard_base_port+0x03:
+        case sdcard_base_port+0x04:
+        case sdcard_base_port+0x05:
+        case sdcard_base_port+0x06:
+        case sdcard_base_port+0x07:
+            sdcard_reg_wr((address & 0xFF), value);
+            break;
+        case sdcard_base_port+0x0F:
+            sdcard_cmd_wr(value);
             break;
         default:
             report("[IOW %04x %02x]", address, value);

--- a/teensy/utils/create_test_disks.py
+++ b/teensy/utils/create_test_disks.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import sys
+
+output = open(sys.argv[1], 'w')
+
+for x in range(0,256):
+    for y in range(0,256):
+        for z in range (0,256):
+            output.write(bytearray([x, y, z]))
+            
+output = open(sys.argv[2], 'w')
+
+for x in range(0,256):
+    for y in range(0,256):
+        output.write(bytearray([x, y]))
+
+output = open(sys.argv[3], 'w')
+
+for x in range(0,256):
+    for y in range(0,256):
+        for z in range (0,256):
+            output.write(bytearray([0, 0, 0]))
+            
+output = open(sys.argv[4], 'w')
+
+for x in range(0,256):
+    for y in range(0,256):
+        output.write(bytearray([0, 0]))

--- a/teensy/z80.cpp
+++ b/teensy/z80.cpp
@@ -773,7 +773,9 @@ void load_file_to_sram(char *filename, uint16_t address, uint16_t start_address)
       testFile.close();
     }
     else {
-      report("error opening file!\r\n");
+      report("error opening file ");
+      report(filename);
+      report("\r\n");
     }
 
     // restore machine state

--- a/teensy/z80.h
+++ b/teensy/z80.h
@@ -66,7 +66,12 @@ uint8_t z80_bus_data(void);
 void z80_set_release_wait(bool release);
 void z80_setup_drive_data(uint8_t data);
 void z80_shutdown_drive_data(void);
+void z80_memory_write(uint16_t address, uint8_t data);
+uint8_t z80_memory_read(uint16_t address);
 void z80_set_mmu(int bank, uint8_t page);
+void begin_dma(void);
+void end_dma(void);
+
 
 void z80_show_pin_states(void);
 void z80_bus_report_state(void);


### PR DESCRIPTION
Reads tested w/128KB and 50MB files
Writes tested w/128KB file
Tested reading/writing ~240 256-byte sectors at the same time.  (w00t!)
The interface to the Z80 should be well defined enough to start to implement a CP/M BIOS to give this some more stress testing (like a drive to drive file copy).